### PR TITLE
Use Public API on Flattening Where Possible

### DIFF
--- a/xarray_jax/tests/test_types.py
+++ b/xarray_jax/tests/test_types.py
@@ -98,7 +98,6 @@ def test_grads(xr_data):
     val, grad = eqx.filter_value_and_grad(fn)(xr_data)
     assert val == (xr_data**2.0).sum().data
     xr.testing.assert_allclose(grad, expected)
-    assert grad.assert_allclose(expected)
 
 
 @given(xr_data=float_vars_and_das)

--- a/xarray_jax/tests/test_types.py
+++ b/xarray_jax/tests/test_types.py
@@ -93,10 +93,11 @@ def test_grads(xr_data):
 
     grad = jax.grad(fn)(xr_data)
     expected = 2 * xr_data
-    assert grad.assert_allclose(expected)
+    xr.testing.assert_allclose(grad, expected)
 
     val, grad = eqx.filter_value_and_grad(fn)(xr_data)
     assert val == (xr_data**2.0).sum().data
+    xr.testing.assert_allclose(grad, expected)
     assert grad.assert_allclose(expected)
 
 

--- a/xarray_jax/tests/test_types.py
+++ b/xarray_jax/tests/test_types.py
@@ -24,13 +24,7 @@ def test_variables(var: xr.Variable, ufunc):
     var_mask = jax.tree.map(lambda _: True, var)
     assert var_mask._data is True
     assert var_mask._dims == var._dims
-
-    # xarray_jax converts None to {} for attrs.
-    # https://github.com/pydata/xarray/issues/9560
-    if var._attrs is None:
-        assert var_mask._attrs == {}
-    else:
-        assert var_mask._attrs == var._attrs
+    assert var_mask.attrs == var.attrs
 
 
 @given(

--- a/xarray_jax/tests/test_types.py
+++ b/xarray_jax/tests/test_types.py
@@ -99,11 +99,11 @@ def test_grads(xr_data):
 
     grad = jax.grad(fn)(xr_data)
     expected = 2 * xr_data
-    assert grad.equals(expected)
+    assert grad.assert_allclose(expected)
 
     val, grad = eqx.filter_value_and_grad(fn)(xr_data)
     assert val == (xr_data**2.0).sum().data
-    assert grad.equals(expected)
+    assert grad.assert_allclose(expected)
 
 
 @given(xr_data=float_vars_and_das)


### PR DESCRIPTION
On flattening, use the public API for accessing attributes where possible.

**Public API Works**
- `xr.Variable.dims`
- `xr.Variable.attrs`
- `xr.DataArray.variable`
- `xr.DataArray.name`
- `xr.Dataset.dims`
- `xr.Dataset.attrs`

**Public API Does Not Work**
- `xr.Variable.data` breaks tree masking (e.g. `jax.tree.map(lambda _: bool, tree)`)
- `xr.DataArray.coords` Root Cause TBD
- `xr.DataArray.indexes` Root Cause TBD
- `xr.Dataset.coords` Root Cause TBD
- `xr.Dataset.indexes` Root Cause TBD


Also fix some type hints.